### PR TITLE
Updated to use the latest version of tokens

### DIFF
--- a/adapter/server/http.go
+++ b/adapter/server/http.go
@@ -281,9 +281,9 @@ func (server *httpServer) getBalancesHandler(reqHandler Handler) http.HandlerFun
 			return
 		}
 
-		token := tokens.ParseToken(tokenName)
-		if token == tokens.InvalidToken {
-			server.writeError(w, r, http.StatusBadRequest, fmt.Sprintf("invalid token name: %s", tokenName))
+		token, err := tokens.PatchToken(tokenName)
+		if err != nil {
+			server.writeError(w, r, http.StatusBadRequest, err.Error())
 		}
 
 		balance, err := reqHandler.GetBalance(password, token)
@@ -353,11 +353,11 @@ func (server *httpServer) getAddressesHandler(reqHandler Handler) http.HandlerFu
 			}
 			server.writeResponse(w, r, http.StatusOK, respBytes)
 		} else {
-			token := tokens.ParseToken(tokenName)
-			if token == tokens.InvalidToken {
-				server.writeError(w, r, http.StatusBadRequest, fmt.Sprintf("invalid token name: %s", tokenName))
-				return
+			token, err := tokens.PatchToken(tokenName)
+			if err != nil {
+				server.writeError(w, r, http.StatusBadRequest, err.Error())
 			}
+
 			address, err := reqHandler.GetAddress(password, token)
 			if err != nil {
 				server.writeError(w, r, http.StatusBadRequest, fmt.Sprintf("unable to retrieve address for token: %s", tokenName))

--- a/adapter/wallet/transfer.go
+++ b/adapter/wallet/transfer.go
@@ -22,7 +22,7 @@ func (wallet *wallet) Transfer(password string, token tokens.Token, to string, a
 	case tokens.ERC20:
 		return wallet.transferERC20(password, token, to, amount, speed, sendAll)
 	default:
-		return "", blockchain.Cost{}, tokens.NewErrUnsupportedToken(token.Name)
+		return "", blockchain.Cost{}, tokens.NewErrUnsupportedToken(string(token.Name))
 	}
 }
 


### PR DESCRIPTION
**Description**

Updated swapperd to work with the latest version of the tokens repository.

**Motivation**

Changes introduced in the latest version of tokens will break the current version of swapperd. To avoid this swapperd is updated to work with the newest version of tokens.

**Design**

- Updated to use tokens.PatchToken() instead of tokens.ParseToken().