### PR TITLE
Fix inaccurate error message

### DIFF
--- a/adapter/wallet/amount.go
+++ b/adapter/wallet/amount.go
@@ -68,7 +68,7 @@ func (wallet *wallet) verifyERC20Balance(password string, token tokens.Token, am
 		}
 
 		if erc20Amount.Cmp(expectedAmount) < 0 {
-			return fmt.Errorf("You must have at least %s %s remaining in your wallet to execute the swap. You have %s %s", expectedAmount, token.Name, erc20Amount, token.Name)
+			return fmt.Errorf("Invalid %s balance. Needed at least %s, but got %s", token.Name, expectedAmount, erc20Amount)
 		}
 	}
 


### PR DESCRIPTION
**Description**

This PR addresses the inaccurate error message given when an insufficient balance error occurs.

**Motivation**

The units are incorrect when checking for sufficient balance. The units are in the smallest available ERC20 unit. We do not have a way to determine the name of the smallest possible ERC20 unit (e.g. Satoshi for BTC, Wei in ETH, and Ai in REN). Converting the BigInt into a float to show the correct units will require the addition of a BigFloat library.

**Design**

Simply change the error message around to be a bit clearer on the unit of token.