### PR TITLE
Disable autoupdate in nightly branch

### DIFF
--- a/driver/updater/updater.go
+++ b/driver/updater/updater.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+bool DISABLE_NIGHTLY_AUTOUPDATE = true
+
 type Updater struct {
 	homeDir string
 	logger  logrus.FieldLogger
@@ -250,6 +252,9 @@ func compareTags(curr, latest []string) (bool, error) {
 	currType, err := convertTypeToNumber(curr[0])
 	if err != nil {
 		return false, err
+	}
+	if DISABLE_NIGHTLY_AUTOUPDATE && currType == 1 {
+		return false, nil
 	}
 
 	latestType, err := convertTypeToNumber(latest[0])

--- a/driver/updater/updater.go
+++ b/driver/updater/updater.go
@@ -21,7 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-bool DISABLE_NIGHTLY_AUTOUPDATE = true
+const DisableNightlyAutoUpdate = true
 
 type Updater struct {
 	homeDir string
@@ -253,7 +253,7 @@ func compareTags(curr, latest []string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if DISABLE_NIGHTLY_AUTOUPDATE && currType == 1 {
+	if DisableNightlyAutoUpdate && currType == 1 {
 		return false, nil
 	}
 


### PR DESCRIPTION
**Description**

Disables the autoupdate feature in nightly branch

**Motivation**

When testing pre-releases built from nightly, we want to ensure that it doesn't autoupdate to the latest stable.

**Design**

When comparing version tags, we return `false` if current version is `"nightly"`.