### PR TITLE
Fix ambiguous nightly tag name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
     steps:
       - core/install_ghr
       - core/github_release:
-          tag: nightly
+          tag: latest_nightly
           filelist: ./RELEASE
           prerelease: true
   stable_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,7 @@ commands:
           tag: latest_nightly
           filelist: ./RELEASE
           prerelease: true
+          replace: true
   stable_release:
     description: Creating Github Release
     steps:


### PR DESCRIPTION
**Description**

There was an issue with nightly not being merged correctly because there existed a tag name called `nightly` and a branch with the same name. This PR will tag the latest nightly releases with `latest_nightly`.