### PR TITLE
Fix for the flickering tokens issue

### DIFF
--- a/adapter/wallet/account.go
+++ b/adapter/wallet/account.go
@@ -59,7 +59,7 @@ func (wallet *wallet) BitcoinAccount(password string) (libbtc.Account, error) {
 }
 
 func (wallet *wallet) ethereumClient() (libeth.Client, error) {
-	return libeth.NewMercuryClient(wallet.config.Ethereum.Network.Name, "swapperd")
+	return libeth.NewInfuraClient(wallet.config.Ethereum.Network.Name, "172978c53e244bd78388e6d50a4ae2fa")
 }
 
 func (wallet *wallet) bitcoinClient() (libbtc.Client, error) {


### PR DESCRIPTION
**Description**

Updated to use infura instead of mercury.

**Motivation**

Mercury is not able to handle the swapperd load and ends up failing which causes 400 Bad request error when calling balances. Which causes a flickering issue in swapperd desktop and renex.

**Design**

- updared to use libeth.InfuraClient instead of libeth.MercuryClient
