### PR TITLE
Hotfix: Nightly install script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 MAIN_VERSION = $(shell cat ./VERSION)
-# BRANCH = $(shell git branch | grep \* | cut -d ' ' -f2)
-BRANCH = nightly
+BRANCH = $(shell git branch | grep \* | cut -d ' ' -f2)
 COMMIT_HASH = $(shell git describe --always --long)
 FULL_VERSION = ${MAIN_VERSION}-${BRANCH}-${COMMIT_HASH}
 
@@ -26,8 +25,6 @@ $(WIN_TARGET): windows
 $(INSTALL_SCRIPT): script
 
 script:
-	@echo ${BRANCH}
-	@sh generate_install.sh ${BRANCH}
 	@sh generate_install.sh ${BRANCH} > ${INSTALL_SCRIPT}
 
 darwin: build-unix

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 MAIN_VERSION = $(shell cat ./VERSION)
-BRANCH = $(shell git branch | grep \* | cut -d ' ' -f2)
+# BRANCH = $(shell git branch | grep \* | cut -d ' ' -f2)
+BRANCH = nightly
 COMMIT_HASH = $(shell git describe --always --long)
 FULL_VERSION = ${MAIN_VERSION}-${BRANCH}-${COMMIT_HASH}
 
@@ -25,6 +26,8 @@ $(WIN_TARGET): windows
 $(INSTALL_SCRIPT): script
 
 script:
+	@echo ${BRANCH}
+	@sh generate_install.sh ${BRANCH}
 	@sh generate_install.sh ${BRANCH} > ${INSTALL_SCRIPT}
 
 darwin: build-unix

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ $(WIN_TARGET): windows
 $(INSTALL_SCRIPT): script
 
 script:
-	@sh generate_install.sh ${BRANCH} > ${INSTALL_SCRIPT}
+	@sh generate_install.sh > ${INSTALL_SCRIPT}
 
 darwin: build-unix
 	@mkdir -p bin

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ zip: installer updater swapperd swapperd-updater uninstaller
 	@echo "Compiled ${LOCAL_TARGET} (${FULL_VERSION})"
 
 clean:
-	rm -rf ${DARWIN_TARGET} ${WIN_TARGET} ${LINUX_TARGET} ${INSTALL_SCRIPT}
+	rm -rf ${DARWIN_TARGET} ${WIN_TARGET} ${LINUX_TARGET}
 
 version:
 	@echo ${FULL_VERSION}

--- a/generate_install.sh
+++ b/generate_install.sh
@@ -9,7 +9,7 @@ else
   BRANCH=$1
 fi
 
-if [ "$BRANCH" == "nightly" ]; then
+if [ "$BRANCH" = "nightly" ]; then
   VERSION=latest_nightly
 else
   VERSION="v$(make --no-print-directory version)"

--- a/generate_install.sh
+++ b/generate_install.sh
@@ -10,7 +10,7 @@ else
 fi
 
 if [ "$BRANCH" == "nightly" ]; then
-  VERSION=nightly
+  VERSION=latest_nightly
 else
   VERSION="v$(make --no-print-directory version)"
 fi

--- a/generate_install.sh
+++ b/generate_install.sh
@@ -1,13 +1,7 @@
 #!/bin/sh
 
 RELEASES_URL="https://github.com/renproject/swapperd/releases"
-
-if [ -z "$1" ]
-then
-  BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
-else
-  BRANCH=$1
-fi
+BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
 
 if [ "$BRANCH" = "nightly" ]; then
   VERSION=latest_nightly


### PR DESCRIPTION
The install script for nightly is not generating correctly due to a confusion with string comparison in `sh` vs `bash`. This PR fixes this issue.